### PR TITLE
Adding pipeline header to vcf

### DIFF
--- a/docker/bcftools/Dockerfile
+++ b/docker/bcftools/Dockerfile
@@ -1,0 +1,36 @@
+# TAG dnastack/bcftools:1.16
+FROM ubuntu:xenial
+
+MAINTAINER Karen Fang <karen@dnastack.com>
+
+RUN apt-get -qq update && \
+	apt-get -qq install \
+		build-essential \
+		wget \
+		tar \
+		autoconf \
+		bzip2 \
+		lbzip2 \
+		libbz2-dev \
+  		libcurl4-openssl-dev \
+  		liblzma-dev \
+  		ncurses-dev \
+ 		libncurses5-dev \
+		zlib1g-dev \
+		libbz2-dev \
+		jq \
+		curl && \
+	rm -rf /var/lib/apt/lists/*
+
+# bcftools
+ENV BCFTOOLS_VERSION 1.16
+RUN wget https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
+	tar -xvf bcftools-${BCFTOOLS_VERSION}.tar.bz2 --directory /opt && \
+	rm bcftools-${BCFTOOLS_VERSION}.tar.bz2
+RUN	cd /opt/bcftools-${BCFTOOLS_VERSION} && \
+	autoheader && \
+	autoconf && \
+	./configure && \
+	make && \
+	make install
+ENV PATH $PATH:/opt/bcftools-${BCFTOOLS_VERSION}

--- a/workflows/illumina_PE/monkeypox_illumina_PE.wdl
+++ b/workflows/illumina_PE/monkeypox_illumina_PE.wdl
@@ -56,6 +56,13 @@ workflow monkeypox_illumina_PE {
       ref_dict = ref_dict
   }
 
+  call pipeline_header_vcf {
+    input:
+      accession = accession, 
+      container_registry = container_registry,
+      initial_vcf = call_variants.initial_vcf
+  }
+
   call assemble_genome {
     input:
       accession = accession,
@@ -74,7 +81,8 @@ workflow monkeypox_illumina_PE {
     Array [File] fastq_files = [download_fastqs.fastq_R1, download_fastqs.fastq_R2]
     File aligned_sorted_bam = align.aligned_sorted_bam
     Array [File] bam_files = [mark_duplicates.markdup_bam, mark_duplicates.markdup_bam_index]
-    Array [File] vcf_files = [call_variants.vcf, call_variants.vcf_index] 
+    File vcf = pipeline_header_vcf.vcf
+    File vcf_index = call_variants.vcf_index
     Array [File] assembly_files = [assemble_genome.assembly, assemble_genome.assembly_quality]
     File sample_metadata = download_fastqs.sample_metadata
     File lineage_metadata = assign_lineage.lineage_metadata
@@ -192,11 +200,11 @@ task call_variants {
     gatk HaplotypeCaller \
       -R "~{ref}" \
       -I "~{markdup_bam}" \
-      -O "~{accession}.vcf.gz" \
+      -O "initial.~{accession}.vcf.gz" \
   >>>
 
   output {
-    File vcf = "~{accession}.vcf.gz"
+    File initial_vcf = "initial.~{accession}.vcf.gz"
     File vcf_index = "~{accession}.vcf.gz.tbi"
   }
 
@@ -207,6 +215,42 @@ task call_variants {
     disks: "local-disk " + disk_size + " HDD"
     preemptible: 2 
     bootDiskSizeGb: 20
+  }
+}
+
+task pipeline_header_vcf {
+  input {
+    String accession
+    String container_registry
+    File initial_vcf
+  }
+
+  Int disk_size = ceil(size(initial_vcf, "GB") + 20)
+
+  command <<<
+    pipeline_release=$(curl -s GET https://api.github.com/repos/DNAstack/monkeypox-processing-pipeline/tags | jq -r '.[].name' | head -1)
+
+    # Write out the header to be modified
+    bcftools view -h ~{initial_vcf} > header
+
+    # Edit the header 
+    line="$(grep -n '#CHROM' header | cut -f1 -d:)"
+    sed -i "$(($line))i\##pipeline=https://github.com/DNAstack/monkeypox-processing-pipeline/releases/tag/$pipeline_release" header
+
+    # Reheader the file
+    bcftools reheader -h header -o "~{accession}.vcf.gz" ~{initial_vcf}
+  >>>
+
+  output {
+    File vcf = "~{accession}.vcf.gz"
+  }
+
+  runtime {
+    docker: "~{container_registry}/bcftools:1.16"
+    cpu: 2
+    memory: "7.5 GB"
+    disks: "local-disk " + disk_size + " HDD"
+    preemptible: 2
   }
 }
 


### PR DESCRIPTION
- Created a bcftools (including jq and curl) docker image and pushed to both the public dnastack Docker Hub and private dnastack GCP: `~{container_registry}/bcftools:1.16`.
- Created a separate task to add the pipeline header to vcf.
- Tested on sample vcf.
- Need to bump version after merge to master.